### PR TITLE
Fixed fetching assets list bug

### DIFF
--- a/src/stores/AccountStore.ts
+++ b/src/stores/AccountStore.ts
@@ -51,7 +51,7 @@ class AccountStore extends SubStore {
             }))
         ];
 
-        const ids: any = assets.balances.filter(balance => balance.issueTransaction === null).map(x => x.assetId);
+        const ids: any = assets.balances.filter(balance => balance.issueTransaction == null).map(x => x.assetId);
         if (ids.length !== 0) {
             const assetDetails = await axios.post('/assets/details', {ids}, {baseURL: `${checkSlash(server)}`});
 
@@ -67,7 +67,7 @@ class AccountStore extends SubStore {
             });
         }
 
-        if ('balances' in assets && !assets.balances.some(x => x.issueTransaction === null)) {
+        if ('balances' in assets && !assets.balances.some(x => x.issueTransaction == null)) {
             this.rootStore.accountStore.assets = {
                 'WAVES': {name: 'WAVES', assetId: 'WAVES', decimals: 8},
                 ...assets.balances.reduce((acc, {assetId, issueTransaction: {name, decimals}}) =>


### PR DESCRIPTION
Fix for empty asset list in some accounts.
If account have an asset issued by Invoke transactions it won't have `IssueTransaction` in asset/balances.
Original comparison will always be false:
```
null === undefined; // false
null == undefined; // true
```